### PR TITLE
feat(api): Añadir utilidad de token y funciones de API de backend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1929,7 +1929,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,4 +1,7 @@
 // ========================================================
-//                      ARCHIVO BARRIL
+//                      ARCHIVO BARRIL - API
 // ========================================================
-export * from "./auth.api";
+
+export * from './auth.api';
+export * from './tasks.api';
+export * from './users.api';

--- a/src/api/tasks.api.js
+++ b/src/api/tasks.api.js
@@ -1,0 +1,114 @@
+//                        API DE TAREAS
+// Funciones para comunicarse con el backend en /api/tasks.
+// Todas las peticiones son autenticadas y manejan el refresco
+// de token automáticamente a través de apiFetch.
+
+import { apiFetch } from '../utils/auth.utils';
+
+// OPERACIONES GET
+
+/**
+ * Obtiene todas las tareas.
+ * @returns {Promise<Array>} Lista de tareas
+ * @throws {Error} Si el servidor responde con error
+ */
+export async function fetchTasks() {
+    const res = await apiFetch('/api/tasks');
+    const response = await res.json();
+
+    if (!response.success) {
+        throw new Error(response.message || 'Error al obtener las tareas');
+    }
+
+    return response.data;
+}
+
+/**
+ * Obtiene una tarea por su ID.
+ * @param {number|string} id - ID de la tarea
+ * @returns {Promise<Object>} Objeto tarea
+ * @throws {Error} Si la tarea no existe o hay error de servidor
+ */
+export async function fetchTaskById(id) {
+    const res = await apiFetch(`/api/tasks/${id}`);
+    const response = await res.json();
+
+    if (!response.success) {
+        throw new Error(response.message || 'Error al obtener la tarea');
+    }
+
+    return response.data;
+}
+
+// OPERACIONES POST
+
+/**
+ * Crea una nueva tarea.
+ * @param {Object} task - Datos de la tarea (user_id, title, description, status)
+ * @returns {Promise<Object>} Respuesta completa { success, message, data, errors }
+ * @throws {Error} Si hay error de servidor
+ */
+export async function createTask(task) {
+    const res = await apiFetch('/api/tasks', {
+        method: 'POST',
+        body: JSON.stringify(task),
+    });
+
+    const response = await res.json();
+    return response;
+}
+
+// OPERACIONES PUT 
+
+/**
+ * Reemplaza completamente una tarea (todos los campos requeridos).
+ * @param {number|string} id - ID de la tarea a reemplazar
+ * @param {Object} taskData - Objeto completo de la tarea
+ * @returns {Promise<Object>} Respuesta completa { success, message, data, errors }
+ * @throws {Error} Si hay error de servidor
+ */
+export async function updateTask(id, taskData) {
+    const res = await apiFetch(`/api/tasks/${id}`, {
+        method: 'PUT',
+        body: JSON.stringify(taskData),
+    });
+
+    const response = await res.json();
+    return response;
+}
+
+// OPERACIONES PATCH
+
+/**
+ * Actualiza parcialmente una tarea (solo los campos enviados).
+ * @param {number|string} id - ID de la tarea a actualizar
+ * @param {Object} taskData - Campos a modificar
+ * @returns {Promise<Object>} Respuesta completa { success, message, data, errors }
+ * @throws {Error} Si hay error de servidor
+ */
+export async function updateTaskPartial(id, taskData) {
+    const res = await apiFetch(`/api/tasks/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify(taskData),
+    });
+
+    const response = await res.json();
+    return response;
+}
+
+// OPERACIONES DELETE
+
+/**
+ * Elimina una tarea por su ID.
+ * @param {number|string} id - ID de la tarea a eliminar
+ * @returns {Promise<Object>} Respuesta completa { success, message, data, errors }
+ * @throws {Error} Si hay error de servidor
+ */
+export async function deleteTask(id) {
+    const res = await apiFetch(`/api/tasks/${id}`, {
+        method: 'DELETE',
+    });
+
+    const response = await res.json();
+    return response;
+}

--- a/src/api/users.api.js
+++ b/src/api/users.api.js
@@ -1,0 +1,163 @@
+//                        API DE USUARIOS
+// Funciones para comunicarse con el backend en /api/users.
+// Todas las peticiones son autenticadas y manejan el refresco
+// de token automáticamente a través de apiFetch.
+
+import { apiFetch } from '../utils/auth.utils';
+
+// OPERACIONES GET 
+
+/**
+ * Obtiene todos los usuarios del sistema.
+ * @returns {Promise<Array>} Lista completa de usuarios
+ * @throws {Error} Si hay error de servidor
+ */
+export async function fetchUsers() {
+    const res = await apiFetch('/api/users');
+    const response = await res.json();
+
+    if (!response.success) {
+        throw new Error(response.message || 'Error al obtener los usuarios');
+    }
+
+    return response.data;
+}
+
+/**
+ * Obtiene un usuario por su ID.
+ * @param {number|string} id - ID del usuario
+ * @returns {Promise<Object|null>} Objeto usuario o null si no existe
+ * @throws {Error} Si hay error de servidor (distinto a 404)
+ */
+export async function fetchUserById(id) {
+    const res = await apiFetch(`/api/users/${id}`);
+    const response = await res.json();
+
+    if (!response.success) return null;
+
+    return response.data;
+}
+
+/**
+ * Obtiene un usuario buscando por número de documento (?document=...).
+ * @param {number|string} document - Número de documento
+ * @returns {Promise<Object>} Respuesta completa { success, message, data, errors }
+ * @throws {Error} Si hay error 5xx de servidor
+ */
+export async function fetchUserByDocument(document) {
+    const res = await apiFetch(`/api/users?document=${document}`);
+
+    if (res.status >= 500) {
+        throw new Error('Error del servidor al buscar el usuario');
+    }
+
+    const response = await res.json();
+    return response; // { success, message, data, errors }
+}
+
+/**
+ * Obtiene los roles asignados a un usuario.
+ * @param {number|string} id - ID del usuario
+ * @returns {Promise<Array>} Lista de roles del usuario
+ * @throws {Error} Si hay error de servidor
+ */
+export async function fetchUserRoles(id) {
+    const res = await apiFetch(`/api/users/${id}/roles`);
+    const response = await res.json();
+
+    if (!response.success) {
+        throw new Error(response.message || 'Error al obtener los roles del usuario');
+    }
+
+    return response.data;
+}
+
+/**
+ * Obtiene los permisos efectivos de un usuario.
+ * @param {number|string} id - ID del usuario
+ * @returns {Promise<Array>} Lista de permisos del usuario
+ * @throws {Error} Si hay error de servidor
+ */
+export async function fetchUserPermissions(id) {
+    const res = await apiFetch(`/api/users/${id}/permissions`);
+    const response = await res.json();
+
+    if (!response.success) {
+        throw new Error(response.message || 'Error al obtener los permisos del usuario');
+    }
+
+    return response.data;
+}
+
+// OPERACIONES POST 
+
+/**
+ * Crea un nuevo usuario en el sistema.
+ * @param {Object} userData - Datos del usuario (name, email, document, password)
+ * @returns {Promise<Object>} Respuesta completa { success, message, data, errors }
+ * @throws {Error} Si hay error de servidor
+ */
+export async function createUser(userData) {
+    const res = await apiFetch('/api/users', {
+        method: 'POST',
+        body: JSON.stringify(userData),
+    });
+
+    const response = await res.json();
+    return response;
+}
+
+// OPERACIONES PUT 
+
+/**
+ * Reemplaza completamente un usuario (todos los campos requeridos).
+ * @param {number|string} id - ID del usuario
+ * @param {Object} userData - Objeto completo con los datos del usuario
+ * @returns {Promise<Object>} Respuesta completa { success, message, data, errors }
+ * @throws {Error} Si hay error de servidor
+ */
+export async function updateUser(id, userData) {
+    const res = await apiFetch(`/api/users/${id}`, {
+        method: 'PUT',
+        body: JSON.stringify(userData),
+    });
+
+    const response = await res.json();
+    return response;
+}
+
+// OPERACIONES PATCH
+
+/**
+ * Actualiza parcialmente un usuario (solo los campos enviados).
+ * @param {number|string} id - ID del usuario
+ * @param {Object} userData - Campos a modificar
+ * @returns {Promise<Object>} Respuesta completa { success, message, data, errors }
+ * @throws {Error} Si hay error de servidor
+ */
+export async function updateUserPartial(id, userData) {
+    const res = await apiFetch(`/api/users/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify(userData),
+    });
+
+    const response = await res.json();
+    return response;
+}
+
+// OPERACIONES DELETE
+
+/**
+ * Elimina un usuario por su ID.
+ * @param {number|string} id - ID del usuario a eliminar
+ * @returns {Promise<Object>} Respuesta completa { success, message, data, errors }
+ * @throws {Error} Si hay error de servidor
+ */
+export async function deleteUser(id) {
+    const res = await apiFetch(`/api/users/${id}`, {
+        method: 'DELETE',
+    });
+
+    const response = await res.json();
+    return response;
+}

--- a/src/modules/auth/controller/login.controller.js
+++ b/src/modules/auth/controller/login.controller.js
@@ -1,5 +1,5 @@
 import { login } from "../../../api/index.js";
-import { navigateTo, showToast } from "../../../utils/index.js";
+import { navigateTo, showToast, setTokens } from "../../../utils/index.js";
 import { validateLoginForm } from "../validation/login.validation.js";
 
 export const loginInit = () => {
@@ -7,10 +7,10 @@ export const loginInit = () => {
     // ========================================================
     //                  SELECTORES DEL DOM
     // ========================================================
-    const form = document.querySelector('#login-form');
+    const form        = document.querySelector('#login-form');
     const formDocument = document.querySelector('#documento');
     const formPassword = document.querySelector('#password');
-    const btnSubmit = form.querySelector('.btn-primary');
+    const btnSubmit   = form.querySelector('.btn-primary');
 
     // ========================================================
     //                       EVENTOS
@@ -21,49 +21,37 @@ export const loginInit = () => {
         const userDocument = formDocument.value.trim();
         const userPassword = formPassword.value.trim();
 
-        // Validar formulario
         const isValid = validateLoginForm();
+        if (!isValid) return;
 
-        if (!isValid) {
-            return;
-        }
-
-        btnSubmit.disabled = true;
+        btnSubmit.disabled    = true;
         btnSubmit.textContent = 'Ingresando...';
 
         try {
-
-            // Definir cuerpo de la solicitud
             const userData = {
                 document: userDocument,
                 password: userPassword
             };
 
-            // Enviar login al backend
             const response = await login(userData);
 
-            // En caso de error o credenciales invalidas
             if (!response.success) {
-                const confirm = (response.message || 'Credenciales inválidas o no autorizadas');
-                showToast(confirm, "error");
+                const msg = response.message || 'Credenciales inválidas o no autorizadas';
+                showToast(msg, 'error');
                 console.error('Error de autenticación:', response);
                 return;
             }
 
-            // Guardar tokens y datos del usuario en localtorage
-            const accessToken = response.data.accessToken;
-            const refreshToken = response.data.refreshToken;
-            const user = response.data.user;
+            const { accessToken, refreshToken, user } = response.data;
 
-            localStorage.setItem('accessToken', accessToken);
-            localStorage.setItem('refreshToken', refreshToken);
+            // Guardar tokens usando la utilidad centralizada (claves tm_*)
+            setTokens(accessToken, refreshToken);
+
+            // Guardar datos del usuario
             localStorage.setItem('user', JSON.stringify(user));
 
-            // Redirigir al layout dinámico
             showToast('Inicio de sesión exitoso. Redirigiendo a tu zona de trabajo...', 'success');
 
-
-            // Esperar un momento para mostrar el mensaje de éxito
             setTimeout(() => {
                 navigateTo('#/navigation');
             }, 2000);
@@ -72,11 +60,8 @@ export const loginInit = () => {
             console.error('Error crítico de conexión:', error);
 
         } finally {
-            btnSubmit.disabled = false;
+            btnSubmit.disabled    = false;
             btnSubmit.textContent = 'Entrar';
         }
-    }
-
-
-    );
+    });
 };

--- a/src/utils/auth.utils.js
+++ b/src/utils/auth.utils.js
@@ -1,21 +1,26 @@
-const API_URL = 'http://localhost:3000';
+//                      AUTH UTILS - apiFetch
+// Wrapper de fetch que:
+//  1. Adjunta el access token en cada petición.
+//  2. Si recibe 401, intenta refrescar el token automáticamente.
+//  3. Reintenta las peticiones que estaban en cola con el nuevo token.
+//  4. Si el refresh falla (token expirado/revocado), limpia la sesión
+//     y redirige al login.
 
+import { API_URL, PORT } from '../config/api.config';
+import { getAccessToken, getRefreshToken, setTokens, clearTokens } from './localStorage';
+import { navigateTo } from './navigation';
+
+const BASE_URL = `${API_URL}:${PORT}`;
+
+// Cola de peticiones que llegaron mientras se estaba refrescando el token
 let isRefreshing = false;
 let pendingRequests = [];
 
-const getAccessToken = () => localStorage.getItem('tm_accessToken');
-const getRefreshToken = () => localStorage.getItem('tm_refreshToken');
-
-const setTokens = (access, refresh) => {
-    localStorage.setItem('tm_accessToken', access);
-    if (refresh) localStorage.setItem('tm_refreshToken', refresh);
-};
-
-const clearTokens = () => {
-    localStorage.removeItem('tm_accessToken');
-    localStorage.removeItem('tm_refreshToken');
-};
-
+/**
+ * Resuelve o rechaza todas las peticiones en cola.
+ * @param {Error|null} error
+ * @param {string|null} token - Nuevo access token si el refresh fue exitoso
+ */
 const processQueue = (error, token = null) => {
     pendingRequests.forEach(req => {
         if (error) req.reject(error);
@@ -24,24 +29,55 @@ const processQueue = (error, token = null) => {
     pendingRequests = [];
 };
 
+/**
+ * Realiza una petición fetch añadiendo headers base y el Bearer token.
+ * @param {string} endpoint - Ruta relativa (/api/tasks) o URL absoluta
+ * @param {RequestInit} options - Opciones de fetch
+ * @param {string|null} token - Access token a usar
+ */
 const makeRequest = (endpoint, options, token) => {
-    const url = endpoint.startsWith('http') ? endpoint : `${API_URL}${endpoint}`;
+    const url = endpoint.startsWith('http') ? endpoint : `${BASE_URL}${endpoint}`;
 
     return fetch(url, {
         ...options,
         headers: {
             'Content-Type': 'application/json',
             ...(token && { Authorization: `Bearer ${token}` }),
-            ...options.headers,
+            ...options.headers, // permite sobreescribir headers si es necesario
         },
     });
 };
 
+/**
+ * Wrapper principal de fetch autenticado.
+ * Maneja automáticamente el refresco del access token y la cola de peticiones.
+ *
+ * @param {string} endpoint - Ruta del recurso (ej: '/api/tasks')
+ * @param {RequestInit} options - Opciones de fetch (method, body, etc.)
+ * @returns {Promise<Response>} Respuesta HTTP
+ * @throws {Error} Si la sesión expiró y no fue posible renovarla
+ *
+ * @example
+ * const res = await apiFetch('/api/tasks');
+ * const data = await res.json();
+ *
+ * @example
+ * const res = await apiFetch('/api/tasks', {
+ *     method: 'POST',
+ *     body: JSON.stringify(newTask),
+ * });
+ */
 export const apiFetch = async (endpoint, options = {}) => {
+
+    // Primer intento con el access token actual
     let res = await makeRequest(endpoint, options, getAccessToken());
 
+    // Si no es 401, la petición fue exitosa o tiene otro tipo de error (devolver tal cual)
     if (res.status !== 401) return res;
 
+    // --- Access token expirado: gestionar refresco ---
+
+    // Si ya hay un refresco en curso, encolar esta petición y esperar
     if (isRefreshing) {
         return new Promise((resolve, reject) => {
             pendingRequests.push({
@@ -54,31 +90,39 @@ export const apiFetch = async (endpoint, options = {}) => {
     isRefreshing = true;
 
     try {
-        const refreshRes = await fetch(`${API_URL}/api/auth/refresh`, {
+        // Solicitar nuevo access token al backend
+        const refreshRes = await fetch(`${BASE_URL}/api/auth/refresh`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ refreshToken: getRefreshToken() }),
         });
 
-        if (!refreshRes.ok) throw new Error('Refresh invalid');
+        if (!refreshRes.ok) throw new Error('Refresh token inválido o expirado');
 
         const data = await refreshRes.json();
         const newAccessToken = data?.data?.accessToken;
-        const newRefreshToken = data?.data?.refreshToken;
 
-        if (!newAccessToken) throw new Error('No access token in refresh response');
+        if (!newAccessToken) throw new Error('El servidor no retornó un access token');
 
-        setTokens(newAccessToken, newRefreshToken);
+        // Guardar el nuevo access token (el backend solo renueva el access token)
+        setTokens(newAccessToken);
+
+        // Reintentar la petición original con el nuevo token
         res = await makeRequest(endpoint, options, newAccessToken);
+
+        // Resolver todas las peticiones que estaban en cola
         processQueue(null, newAccessToken);
 
         return res;
 
     } catch (err) {
+
+        // El refresh falló: limpiar sesión y redirigir al login
         processQueue(err, null);
         clearTokens();
-        window.location.hash = '#/login';
-        throw new Error('Sesión expirada');
+        navigateTo('#/login');
+        throw new Error('Sesión expirada. Por favor inicia sesión nuevamente.');
+
     } finally {
         isRefreshing = false;
     }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,8 +1,9 @@
 // ========================================================
-//                      ARCHIVO BARRIL
+//                      ARCHIVO BARRIL - UTILS
 // ========================================================
 
-export * from "./localStorage";
-export * from "./notification";
-export * from "./navigation";
-export * from "./ui.utils";
+export * from './localStorage';
+export * from './auth.utils';
+export * from './notification';
+export * from './navigation';
+export * from './ui.utils';

--- a/src/utils/localStorage.js
+++ b/src/utils/localStorage.js
@@ -1,29 +1,28 @@
+//                      MANEJO DE TOKENS
+// Fuente única de verdad para leer, guardar y limpiar tokens
+// en el localStorage. Prefijo "tm_" para evitar colisiones.
 
-// Consulta si el usuario está autenticado verificando la presencia de un token en el localStorage
+const ACCESS_KEY  = 'tm_accessToken';
+const REFRESH_KEY = 'tm_refreshToken';
 
-// Obtenemos el token de acceso del localStorage
-export const getAccessToken = () => {
-    const accessToken = localStorage.getItem('accessToken');
+/** Obtiene el access token almacenado */
+export const getAccessToken = () => localStorage.getItem(ACCESS_KEY);
 
-    return accessToken;
-}
+/** Obtiene el refresh token almacenado */
+export const getRefreshToken = () => localStorage.getItem(REFRESH_KEY);
 
-// Obtenemos el token de refresco del localStorage
-export const getRefreshToken = () => {
-    const refreshToken = localStorage.getItem('refreshToken');
-
-    return refreshToken;
-}
-
-// Definir tokens en el localStorage
-export const setTokens = (access, refresh) => {
-    localStorage.setItem('accessToken', access);
-
-    if (refresh) localStorage.setItem('refreshToken', refresh);
+/**
+ * Guarda los tokens en el localStorage.
+ * @param {string} access        - Nuevo access token
+ * @param {string|null} refresh  - Nuevo refresh token (null = no actualizar)
+ */
+export const setTokens = (access, refresh = null) => {
+    localStorage.setItem(ACCESS_KEY, access);
+    if (refresh) localStorage.setItem(REFRESH_KEY, refresh);
 };
 
-// Eliminar tokens del localStorage
+/** Elimina ambos tokens del localStorage */
 export const clearTokens = () => {
-    localStorage.removeItem('accessToken');
-    localStorage.removeItem('refreshToken');
+    localStorage.removeItem(ACCESS_KEY);
+    localStorage.removeItem(REFRESH_KEY);
 };


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega la capa de comunicación con el backend: utilidad de tokens y funciones de API para tareas y usuarios.

---

## Cambios

### `src/utils/localStorage.js`
- Unifica el manejo de tokens con prefijo `tm_` para evitar colisiones
- Exporta `getAccessToken`, `getRefreshToken`, `setTokens` y `clearTokens` como fuente única de verdad

### `src/utils/auth.utils.js`
- Refactorizado para importar tokens desde `localStorage.js` y la URL base desde `api.config.js`
- Implementa `apiFetch`: wrapper de `fetch` que adjunta el Bearer token en cada petición
- Si recibe un `401`, intenta refrescar el access token automáticamente contra `/api/auth/refresh`
- Si el refresh falla (token expirado o revocado), limpia la sesión y redirige a `#/login`
- Gestiona cola de peticiones concurrentes durante el refresco

### `src/api/tasks.api.js` _(nuevo)_
- `fetchTasks` — GET /api/tasks
- `fetchTaskById` — GET /api/tasks/:id
- `createTask` — POST /api/tasks
- `updateTask` — PUT /api/tasks/:id
- `updateTaskPartial` — PATCH /api/tasks/:id
- `deleteTask` — DELETE /api/tasks/:id

### `src/api/users.api.js` _(nuevo)_
- `fetchUsers` — GET /api/users
- `fetchUserById` — GET /api/users/:id
- `fetchUserByDocument` — GET /api/users?document=...
- `fetchUserRoles` — GET /api/users/:id/roles
- `fetchUserPermissions` — GET /api/users/:id/permissions
- `createUser` — POST /api/users
- `updateUser` — PUT /api/users/:id
- `updateUserPartial` — PATCH /api/users/:id
- `deleteUser` — DELETE /api/users/:id

### `src/api/index.js` y `src/utils/index.js`
- Actualizados para exportar los nuevos módulos desde los archivos barril

---

## Notas
- Todas las peticiones autenticadas pasan por `apiFetch`, no por `fetch` directamente
- Los mensajes de error provienen del backend (`response.message` / `response.errors`)
- La capa de servicios (notificaciones, lógica de negocio) queda pendiente para el siguiente PR