### PR TITLE
feat(roles-permisos): implementar módulo completo de roles y permisos

### DIFF
--- a/src/api/apiClient.js
+++ b/src/api/apiClient.js
@@ -1,8 +1,10 @@
-import { API_URL } from '../config/api.config.js';
-import { getAccessToken, getRefreshToken, setTokens, clearAuth } from '../utils/auth.utils.js';
+import { API_URL, PORT } from '../config/api.config.js';
+import { getAccessToken, getRefreshToken, setTokens, clearTokens } from '../utils/localStorage.js';
 
 let isRefreshing = false;
 let failedQueue = [];
+
+const BASE_URL = `${API_URL}:${PORT}`;
 
 const processQueue = (error, token = null) => {
     failedQueue.forEach(prom => {
@@ -26,15 +28,15 @@ const processQueue = (error, token = null) => {
     const config = { ...options, headers };
 
     try {
-        let response = await fetch(`${API_URL}${endpoint}`, config);
+        let response = await fetch(`${BASE_URL}${endpoint}`, config);
 
         if (response.status === 401) {
         const refreshToken = getRefreshToken();
         
         if (!refreshToken) {
-            clearAuth();
-            window.dispatchEvent(new CustomEvent('auth-expired'));
-            throw new Error('Sesión expirada');
+            clearTokens();
+            window.location.hash = '#/login';
+    throw new Error('Sesión expirada');
         }
 
         if (isRefreshing) {
@@ -42,14 +44,14 @@ const processQueue = (error, token = null) => {
             failedQueue.push({ resolve, reject });
             }).then(newToken => {
             config.headers['Authorization'] = `Bearer ${newToken}`;
-            return fetch(`${API_URL}${endpoint}`, config).then(res => parseResponse(res));
+            return fetch(`${BASE_URL}${endpoint}`, config).then(res => parseResponse(res));
             });
         }
 
         isRefreshing = true;
 
         try {
-            const refreshResponse = await fetch(`${API_URL}/api/auth/refresh`, {
+            const refreshResponse = await fetch(`${BASE_URL}/api/auth/refresh`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ refreshToken }) 
@@ -66,14 +68,14 @@ const processQueue = (error, token = null) => {
             processQueue(null, newAccessToken);
 
             config.headers['Authorization'] = `Bearer ${newAccessToken}`;
-            response = await fetch(`${API_URL}${endpoint}`, config);
+            response = await fetch(`${BASE_URL}${endpoint}`, config);
 
         } catch (refreshError) {
             isRefreshing = false;
             processQueue(refreshError, null);
-            clearAuth();
-            window.dispatchEvent(new CustomEvent('auth-expired'));
-            throw refreshError;
+            clearTokens();
+            window.location.hash = '#/login';
+                throw new Error('Sesión expirada. Por favor inicia sesión nuevamente.');
         }
         }
 

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -6,3 +6,5 @@ export * from './auth.api';
 export * from './tasks.api';
 export * from './users.api';
 export * from './settings.api';
+export * from './roles.api.js';
+export * from './permissions.api.js';

--- a/src/api/permissions.api.js
+++ b/src/api/permissions.api.js
@@ -1,0 +1,10 @@
+import { apiClient } from './apiClient.js';
+
+/**
+ * Obtiene todos los permisos del sistema.
+ * @returns {Promise<Array>} Lista de permisos { id, code, name, description }
+ */
+export const fetchPermissions = async () => {
+    const res = await apiClient('/api/permissions');
+    return res?.data ?? res;
+};

--- a/src/api/roles.api.js
+++ b/src/api/roles.api.js
@@ -54,3 +54,26 @@ export const deleteRole = async (id) => {
         method: 'DELETE',
     });
 };
+
+/**
+ * Obtiene los permisos asignados a un rol.
+ * @param {number|string} id
+ * @returns {Promise<Array>} Lista de permisos del rol
+ */
+export const fetchRolePermissions = async (id) => {
+    const res = await apiClient(`/api/roles/${id}/permissions`);
+    return res?.data ?? res;
+};
+
+/**
+ * Sincroniza los permisos de un rol (reemplaza los existentes).
+ * @param {number|string} id
+ * @param {number[]} permissionIds
+ * @returns {Promise<Object>} Respuesta { success, message, data }
+ */
+export const assignRolePermissions = async (id, permissionIds) => {
+    return await apiClient(`/api/roles/${id}/permissions`, {
+        method: 'POST',
+        body: JSON.stringify({ permissionIds }),
+    });
+};

--- a/src/api/roles.api.js
+++ b/src/api/roles.api.js
@@ -1,0 +1,56 @@
+import { apiClient } from './apiClient.js';
+
+/**
+ * Obtiene todos los roles del sistema.
+ * @returns {Promise<Array>} Lista de roles { id, name, description }
+ */
+export const fetchRoles = async () => {
+    const res = await apiClient('/api/roles');
+    return res?.data ?? res;
+};
+
+/**
+ * Obtiene un rol por su ID.
+ * @param {number|string} id
+ * @returns {Promise<Object>} Rol { id, name, description }
+ */
+export const fetchRoleById = async (id) => {
+    const res = await apiClient(`/api/roles/${id}`);
+    return res?.data ?? res;
+};
+
+/**
+ * Crea un nuevo rol.
+ * @param {{ name: string, description: string }} roleData
+ * @returns {Promise<Object>} Respuesta { success, message, data }
+ */
+export const createRole = async (roleData) => {
+    return await apiClient('/api/roles', {
+        method: 'POST',
+        body: JSON.stringify(roleData),
+    });
+};
+
+/**
+ * Actualiza parcialmente un rol existente.
+ * @param {number|string} id
+ * @param {{ name?: string, description?: string }} roleData
+ * @returns {Promise<Object>} Respuesta { success, message, data }
+ */
+export const updateRolePartial = async (id, roleData) => {
+    return await apiClient(`/api/roles/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify(roleData),
+    });
+};
+
+/**
+ * Elimina un rol por su ID.
+ * @param {number|string} id
+ * @returns {Promise<Object>} Respuesta { success, message }
+ */
+export const deleteRole = async (id) => {
+    return await apiClient(`/api/roles/${id}`, {
+        method: 'DELETE',
+    });
+};

--- a/src/modules/rolesAndPermissions/controller/rolesAndPermissions.controller.js
+++ b/src/modules/rolesAndPermissions/controller/rolesAndPermissions.controller.js
@@ -1,0 +1,237 @@
+import { rolesListView, roleCreateView, roleEditView, permissionCardHTML } from '../view/rolesAndPermissions.view.js';
+import { fetchRoles, fetchRoleById, createRole, updateRolePartial, deleteRole, fetchRolePermissions, assignRolePermissions } from '../../../api/roles.api.js';
+import { fetchPermissions } from '../../../api/permissions.api.js';
+import { showToast, showConfirmation } from '../../../utils/notification.js';
+
+// ─── Helper: mostrar/ocultar error de campo ───
+const setFieldError = (id, message = '') => {
+    const el = document.querySelector(`#${id}`);
+    if (!el) return;
+    if (message) {
+        el.textContent = message;
+        el.classList.remove('hidden');
+    } else {
+        el.textContent = '';
+        el.classList.add('hidden');
+    }
+};
+
+// ─── Helper: validar formulario de rol ───
+const validateRoleForm = (name) => {
+    let valid = true;
+    setFieldError('role-name-error');
+    if (!name || name.trim().length < 2) {
+        setFieldError('role-name-error', 'El nombre debe tener al menos 2 caracteres');
+        valid = false;
+    }
+    return valid;
+};
+
+// ==========================================
+// LISTA DE ROLES + PERMISOS
+// ==========================================
+export const renderRolesList = async (container) => {
+    container.innerHTML = rolesListView();
+
+    // Botón crear rol
+    document.getElementById('btn-create-role')?.addEventListener('click', () => {
+        window.location.hash = '#/rolesAndPermissions/create';
+    });
+
+    const rolesTbody = document.getElementById('roles-table-body');
+    const permissionsGrid = document.getElementById('permissions-grid');
+
+    try {
+        // Cargar roles y permisos en paralelo
+        const [roles, permissions] = await Promise.all([
+            fetchRoles(),
+            fetchPermissions()
+        ]);
+
+        // ─── Renderizar tabla de roles ───
+        const rolesArray = Array.isArray(roles) ? roles : roles?.data ?? [];
+
+        if (rolesArray.length === 0) {
+            rolesTbody.innerHTML = `
+                <tr>
+                    <td colspan="4" style="text-align: center; color: var(--text-muted);">
+                        No hay roles registrados.
+                    </td>
+                </tr>`;
+        } else {
+            rolesTbody.innerHTML = rolesArray.map(role => `
+                <tr>
+                    <td>${role.id}</td>
+                    <td>${role.name}</td>
+                    <td>${role.description ?? '—'}</td>
+                    <td class="actions-cell">
+                        <button class="btn-secondary btn-edit-role" data-id="${role.id}">Editar</button>
+                        <button class="btn-danger btn-delete-role" data-id="${role.id}">Eliminar</button>
+                    </td>
+                </tr>
+            `).join('');
+        }
+
+        // ─── Listeners de tabla ───
+        rolesTbody.addEventListener('click', async (e) => {
+            const id = e.target.getAttribute('data-id');
+
+            if (e.target.classList.contains('btn-edit-role')) {
+                window.location.hash = `#/rolesAndPermissions/edit/${id}`;
+            }
+
+            if (e.target.classList.contains('btn-delete-role')) {
+                const result = await showConfirmation(
+                    '¿Eliminar rol?',
+                    'Esta acción no se puede deshacer'
+                );
+                if (result.isConfirmed) {
+                    try {
+                        await deleteRole(id);
+                        showToast('Rol eliminado correctamente', 'success');
+                        renderRolesList(container);
+                    } catch (err) {
+                        showToast(err?.message ?? 'Error al eliminar el rol', 'error');
+                    }
+                }
+            }
+        });
+
+        // ─── Renderizar permisos ───
+        const permissionsArray = Array.isArray(permissions) ? permissions : permissions?.data ?? [];
+
+        if (permissionsArray.length === 0) {
+            permissionsGrid.innerHTML = `<p style="color: var(--text-muted);">No hay permisos registrados.</p>`;
+        } else {
+            permissionsGrid.innerHTML = permissionsArray.map(p => permissionCardHTML(p)).join('');
+        }
+
+    } catch (err) {
+        console.error('[ERROR] renderRolesList:', err);
+        rolesTbody.innerHTML = `
+            <tr>
+                <td colspan="4" style="text-align: center;" class="error-message">
+                    Error al cargar los roles: ${err?.message ?? 'Error desconocido'}
+                </td>
+            </tr>`;
+    }
+};
+
+// ==========================================
+// CREAR ROL
+// ==========================================
+export const renderCreateRole = (container) => {
+    container.innerHTML = roleCreateView();
+
+    document.getElementById('btn-back-roles')?.addEventListener('click', () => {
+        window.location.hash = '#/rolesAndPermissions';
+    });
+
+    const form = document.getElementById('create-role-form');
+    form?.addEventListener('submit', async (e) => {
+        e.preventDefault();
+
+        const name        = document.getElementById('role-name').value.trim();
+        const description = document.getElementById('role-description').value.trim();
+
+        if (!validateRoleForm(name)) return;
+
+        const btn = document.getElementById('btn-save-role');
+        btn.disabled    = true;
+        btn.textContent = 'Guardando...';
+
+        try {
+            await createRole({ name, description });
+            showToast('Rol creado correctamente', 'success');
+            window.location.hash = '#/rolesAndPermissions';
+        } catch (err) {
+            showToast(err?.message ?? 'Error al crear el rol', 'error');
+            btn.disabled    = false;
+            btn.textContent = 'Guardar Rol';
+        }
+    });
+};
+
+// ==========================================
+// EDITAR ROL
+// ==========================================
+export const renderEditRole = async (container, params) => {
+    const roleId = params?.id;
+
+    if (!roleId) {
+        container.innerHTML = `<div class="error-message"><h2>Error: ID no proporcionado.</h2></div>`;
+        return;
+    }
+
+    container.innerHTML = `
+        <div style="padding: 40px; text-align: center; color: var(--text-muted);">
+            Cargando datos del rol...
+        </div>`;
+
+    try {
+        // Cargar rol, todos los permisos y permisos actuales del rol en paralelo
+        const [roleRes, allPermissions, rolePermissions] = await Promise.all([
+            fetchRoleById(roleId),
+            fetchPermissions(),
+            fetchRolePermissions(roleId)
+        ]);
+
+        const roleData        = Array.isArray(roleRes) ? roleRes[0] : roleRes?.data ?? roleRes;
+        const permissionsArr  = Array.isArray(allPermissions) ? allPermissions : allPermissions?.data ?? [];
+        const assignedIds     = (Array.isArray(rolePermissions) ? rolePermissions : rolePermissions?.data ?? [])
+                                    .map(p => Number(p.id ?? p.permissionId ?? p));
+
+        if (!roleData?.id) {
+            container.innerHTML = `<div class="error-message"><h2>Rol no encontrado.</h2></div>`;
+            return;
+        }
+
+        container.innerHTML = roleEditView(roleData, permissionsArr, assignedIds);
+
+        document.getElementById('btn-back-roles')?.addEventListener('click', () => {
+            window.location.hash = '#/rolesAndPermissions';
+        });
+
+        const form = document.getElementById('edit-role-form');
+        form?.addEventListener('submit', async (e) => {
+            e.preventDefault();
+
+            const name        = document.getElementById('role-name').value.trim();
+            const description = document.getElementById('role-description').value.trim();
+
+            if (!validateRoleForm(name)) return;
+
+            // Obtener permisos seleccionados
+            const selectedPermissionIds = Array.from(
+                document.querySelectorAll('input[name="permissionIds"]:checked')
+            ).map(cb => Number(cb.value));
+
+            if (selectedPermissionIds.length === 0) {
+                showToast('Debes asignar al menos un permiso al rol', 'error');
+                return;
+            }
+
+            const btn = document.getElementById('btn-save-role');
+            btn.disabled    = true;
+            btn.textContent = 'Guardando...';
+
+            try {
+                // Guardar nombre/descripción y permisos en paralelo
+                await Promise.all([
+                    updateRolePartial(roleId, { name, description }),
+                    assignRolePermissions(roleId, selectedPermissionIds)
+                ]);
+                showToast('Rol actualizado correctamente', 'success');
+                window.location.hash = '#/rolesAndPermissions';
+            } catch (err) {
+                showToast(err?.message ?? 'Error al actualizar el rol', 'error');
+                btn.disabled    = false;
+                btn.textContent = 'Guardar cambios';
+            }
+        });
+
+    } catch (err) {
+        console.error('[ERROR] renderEditRole:', err);
+        container.innerHTML = `<div class="error-message">Error: ${err?.message ?? 'Error desconocido'}</div>`;
+    }
+};

--- a/src/modules/rolesAndPermissions/index.js
+++ b/src/modules/rolesAndPermissions/index.js
@@ -2,3 +2,4 @@
 //                      ARCHIVO BARRIL
 // ========================================================
 export * from "./view/rolesAndPermissions.view";
+export * from './controller/rolesAndPermissions.controller.js';

--- a/src/modules/rolesAndPermissions/view/rolesAndPermissions.view.js
+++ b/src/modules/rolesAndPermissions/view/rolesAndPermissions.view.js
@@ -1,8 +1,177 @@
-export const rolesAndPermissionsView = () => {
-    return `
-    <div class="roles-permissions-view">
-        <h1>Roles y Permisos</h1>
-        <p>Esta es la vista de Roles y Permisos. Aquí puedes gestionar los roles y permisos de los usuarios.</p>
+//          VISTA: ROLES Y PERMISOS
+
+/**
+ * Vista principal — lista de roles + catálogo de permisos (solo lectura)
+ */
+export const rolesListView = () => `
+    <div class="dashboard-container">
+
+        <header class="view-header">
+            <h1 class="view-title">Roles y Permisos</h1>
+            <button id="btn-create-role" class="btn-primary" style="width: auto; padding: 10px 20px;">
+                Crear Rol
+            </button>
+        </header>
+
+        <!-- SECCIÓN: ROLES -->
+        <div class="content-card">
+            <h2 class="section-title">Gestión de Roles</h2>
+            <div class="table-container">
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Nombre</th>
+                            <th>Descripción</th>
+                            <th>Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody id="roles-table-body">
+                        <tr>
+                            <td colspan="4" style="text-align: center; color: var(--text-muted);">
+                                Cargando roles...
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <!-- SECCIÓN: PERMISOS -->
+        <div class="content-card" style="margin-top: 24px;">
+            <h2 class="section-title">Permisos del sistema</h2>
+            <p class="section-subtitle">Catálogo de permisos disponibles — solo lectura</p>
+            <div id="permissions-grid" class="permissions-grid">
+                <p style="color: var(--text-muted);">Cargando permisos...</p>
+            </div>
+        </div>
+
     </div>
-    `
-}
+`;
+
+/**
+ * Vista formulario — crear rol
+ */
+export const roleCreateView = () => `
+    <div class="dashboard-container">
+
+        <header class="view-header">
+            <h1 class="view-title">Crear Rol</h1>
+            <button id="btn-back-roles" class="btn-secondary" style="width: auto; padding: 10px 20px;">
+                Volver
+            </button>
+        </header>
+
+        <div class="content-card">
+            <form id="create-role-form" class="form-layout">
+
+                <div class="input-group">
+                    <label for="role-name">Nombre del rol</label>
+                    <div class="input-wrapper">
+                        <input type="text" id="role-name" name="name" placeholder="Ej: Supervisor" required />
+                    </div>
+                    <span class="error-message hidden" id="role-name-error"></span>
+                </div>
+
+                <div class="input-group">
+                    <label for="role-description">Descripción</label>
+                    <div class="input-wrapper">
+                        <input type="text" id="role-description" name="description" placeholder="Ej: Supervisa el trabajo de los aprendices" />
+                    </div>
+                    <span class="error-message hidden" id="role-description-error"></span>
+                </div>
+
+                <div class="form-actions">
+                    <button type="submit" class="btn-primary" id="btn-save-role" style="width: auto; padding: 10px 24px;">
+                        Guardar Rol
+                    </button>
+                </div>
+
+            </form>
+        </div>
+
+    </div>
+`;
+
+/**
+ * Vista formulario — editar rol (precargado con datos del rol)
+ * @param {{ id: number, name: string, description: string }} role
+ * @param {Array} permissions - Todos los permisos del sistema
+ * @param {number[]} assignedIds - IDs de permisos ya asignados al rol
+ */
+export const roleEditView = (role, permissions = [], assignedIds = []) => `
+    <div class="dashboard-container">
+
+        <header class="view-header">
+            <h1 class="view-title">Editar Rol</h1>
+            <button id="btn-back-roles" class="btn-secondary" style="width: auto; padding: 10px 20px;">
+                Volver
+            </button>
+        </header>
+
+        <div class="content-card">
+            <form id="edit-role-form" class="form-layout">
+
+                <div class="input-group">
+                    <label for="role-name">Nombre del rol</label>
+                    <div class="input-wrapper">
+                        <input type="text" id="role-name" name="name" value="${role.name ?? ''}" placeholder="Nombre del rol" required />
+                    </div>
+                    <span class="error-message hidden" id="role-name-error"></span>
+                </div>
+
+                <div class="input-group">
+                    <label for="role-description">Descripción</label>
+                    <div class="input-wrapper">
+                        <input type="text" id="role-description" name="description" value="${role.description ?? ''}" placeholder="Descripción del rol" />
+                    </div>
+                    <span class="error-message hidden" id="role-description-error"></span>
+                </div>
+
+                <div class="input-group">
+                    <label>Permisos asignados</label>
+                    <div class="permissions-checklist" id="permissions-checklist">
+                        ${permissions.length === 0
+                            ? '<p style="color: var(--text-muted); font-size: 13px;">No hay permisos disponibles.</p>'
+                            : permissions.map(p => `
+                                <label class="permission-checkbox-item">
+                                    <input
+                                        type="checkbox"
+                                        name="permissionIds"
+                                        value="${p.id}"
+                                        class="permission-checkbox-input"
+                                        ${assignedIds.includes(p.id) ? 'checked' : ''}
+                                    />
+                                    <div class="permission-checkbox-info">
+                                        <span class="permission-code">${p.code ?? ''}</span>
+                                        <span class="permission-name">${p.name ?? ''}</span>
+                                    </div>
+                                </label>
+                            `).join('')
+                        }
+                    </div>
+                </div>
+
+                <div class="form-actions">
+                    <button type="submit" class="btn-primary" id="btn-save-role" style="width: auto; padding: 10px 24px;">
+                        Guardar cambios
+                    </button>
+                </div>
+
+            </form>
+        </div>
+
+    </div>
+`;
+
+/**
+ * Genera el HTML de una tarjeta de permiso
+ * @param {{ id: number, code: string, name: string, description: string }} permission
+ */
+export const permissionCardHTML = (permission) => `
+    <div class="permission-card">
+        <span class="permission-code">${permission.code ?? ''}</span>
+        <p class="permission-name">${permission.name ?? ''}</p>
+        <p class="permission-desc">${permission.description ?? ''}</p>
+    </div>
+`;

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -8,7 +8,7 @@ import {
     RegisterView
 } from "../modules/auth/index";
 
-import { rolesAndPermissionsView } from "../modules/rolesAndPermissions/index";
+import { rolesListView, renderRolesList, renderCreateRole, renderEditRole} from "../modules/rolesAndPermissions/index";
 import { settingsView, settingsInit } from "../modules/settings/index";
 import { tasksView, tasksInit } from "../modules/tasks/index";
 import { renderUsersList, renderCreateUser, renderEditUser } from "../modules/users/index";
@@ -95,8 +95,32 @@ export const routes = [
     // HASH DE ROLES Y PERMISOS
     {
         path: "#/rolesAndPermissions",
-        view: () => rolesAndPermissionsView(),
-        init: inProgressInit,
+        view: () => `<div id="roles-view-container">Cargando...</div>`,
+        init: () => {
+            const container = document.querySelector("#roles-view-container");
+            if (container) renderRolesList(container);
+        },
+        private: true
+    },
+
+     // HASH CREAR ROL
+    {
+        path: "#/rolesAndPermissions/create",
+        view: () => `<div id="role-create-container">Cargando formulario...</div>`,
+        init: () => {
+            const container = document.querySelector("#role-create-container");
+            if (container) renderCreateRole(container);
+        },
+        private: true
+    },
+    // HASH EDITAR ROL
+    {
+        path: "#/rolesAndPermissions/edit/:id",
+        view: () => `<div id="role-edit-container">Cargando...</div>`,
+        init: (params) => {
+            const container = document.querySelector("#role-edit-container");
+            if (container && params) renderEditRole(container, params);
+        },
         private: true
     },
 

--- a/src/style.css
+++ b/src/style.css
@@ -1702,3 +1702,121 @@ body.theme-mocha {
     width: 60%;
     background: #2a1e18;
 }
+
+/*
+    ROLES Y PERMISOS
+*/
+
+.section-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 4px;
+}
+
+.section-subtitle {
+    font-size: 13px;
+    color: var(--text-muted);
+    margin-bottom: 16px;
+}
+
+/* ---------- Grid de permisos ---------- */
+.permissions-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 12px;
+    margin-top: 12px;
+}
+
+.permission-card {
+    background: var(--bg-primary);
+    border: 1px solid var(--bg-tertiary);
+    border-radius: var(--radius-sm);
+    padding: 14px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.permission-code {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--accent);
+    font-family: monospace;
+}
+
+.permission-name {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0;
+}
+
+.permission-desc {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin: 0;
+}
+
+/* ---------- Formulario ---------- */
+.form-layout {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    max-width: 520px;
+}
+
+.form-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 4px;
+}
+
+/* ---------- Checklist de permisos en editar rol ---------- */
+.permissions-checklist {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 8px;
+    margin-top: 8px;
+    max-height: 320px;
+    overflow-y: auto;
+    padding: 4px 2px;
+}
+
+.permission-checkbox-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--bg-tertiary);
+    background: var(--bg-primary);
+    cursor: pointer;
+    transition: border-color var(--transition), background var(--transition);
+}
+
+.permission-checkbox-item:hover {
+    border-color: var(--accent);
+    background: rgba(59, 130, 246, 0.05);
+}
+
+.permission-checkbox-input {
+    accent-color: var(--accent);
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.permission-checkbox-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+/* Fix: formulario de editar rol centrado */
+#edit-role-form.form-layout {
+    max-width: 100%;
+}


### PR DESCRIPTION
## ¿Qué hace este PR?

Implementa el módulo completo de Roles y Permisos, incluyendo CRUD de roles,
catálogo de permisos de solo lectura y asignación de permisos a roles desde
el formulario de edición.

Closes #51 

---

## Cambios

### `src/api/roles.api.js`
- Funciones existentes: `fetchRoles`, `fetchRoleById`, `createRole`, `updateRolePartial`, `deleteRole`
- Funciones nuevas: `fetchRolePermissions` → `GET /api/roles/:id/permissions` y `assignRolePermissions` → `POST /api/roles/:id/permissions`

### `src/api/permissions.api.js` _(nuevo)_
- `fetchPermissions` → `GET /api/permissions`

### `src/api/index.js`
- Exporta los nuevos módulos `roles.api` y `permissions.api`

### `src/modules/rolesAndPermissions/view/rolesAndPermissions.view.js`
- `rolesListView()` — tabla de roles con columnas ID, nombre, descripción y acciones
- `roleCreateView()` — formulario de creación con nombre y descripción
- `roleEditView(role, permissions, assignedIds)` — formulario de edición precargado con checklist de permisos del sistema; los ya asignados aparecen marcados
- `permissionCardHTML(permission)` — tarjeta de permiso de solo lectura

### `src/modules/rolesAndPermissions/controller/rolesAndPermissions.controller.js` _(nuevo)_
- `renderRolesList` — carga roles y permisos en paralelo, rellena tabla y catálogo de permisos
- `renderCreateRole` — formulario de creación con validación
- `renderEditRole` — carga rol + todos los permisos + permisos del rol en paralelo; al guardar ejecuta `Promise.all([updateRolePartial, assignRolePermissions])`

### `src/modules/rolesAndPermissions/index.js`
- Exporta view y controller

### `src/router/routes.js`
- Rutas `#/rolesAndPermissions`, `#/rolesAndPermissions/create` y `#/rolesAndPermissions/edit/:id` conectadas a sus respectivos renders

### `src/api/apiClient.js` _(corregido)_
- Se define `BASE_URL = \`\${API_URL}:\${PORT}\`` y se usa en todos los `fetch`, incluyendo el refresh y el retry — antes faltaba el puerto en esas dos llamadas, lo que hacía que el refresh siempre fallara
- Se reemplaza `window.dispatchEvent(new CustomEvent('auth-expired'))` por `window.location.hash = '#/login'` — el evento no tenía listener y dejaba al usuario atrapado sin redirección

### `style.css` _(corregido)_
- `#edit-role-form.form-layout { max-width: 100%; }` — el formulario de editar rol quedaba limitado a 520px y descentrado

---

## Notas
- Ninguna acción está bloqueada por `hasPermission()` — la lógica RBAC en la UI se definirá en una etapa posterior
- La sincronización de permisos en el backend es un DELETE + INSERT completo (reemplaza los existentes)