### PR TITLE
feat(settings): edicion de documento en perfil y errores inline

### DIFF
--- a/src/modules/settings/controller/settings.controller.js
+++ b/src/modules/settings/controller/settings.controller.js
@@ -56,9 +56,10 @@ const initPasswordToggles = () => {
 const validateProfileForm = () => {
     const name  = document.querySelector('#profile-name').value.trim();
     const email = document.querySelector('#profile-email').value.trim();
+    const doc      = document.querySelector('#profile-document').value.trim();
     let valid = true;
 
-    clearErrors('profile-name-error', 'profile-email-error');
+    clearErrors('profile-name-error', 'profile-email-error', 'profile-document-error');
 
     if (name.length < 3) {
         setFieldError('profile-name-error', 'El nombre debe tener al menos 3 caracteres');
@@ -67,6 +68,11 @@ const validateProfileForm = () => {
 
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
         setFieldError('profile-email-error', 'Ingresa un correo electrónico válido');
+        valid = false;
+    }
+
+    if (doc && !/^\d{5,15}$/.test(doc)) {
+        setFieldError('profile-document-error', 'El documento debe contener entre 5 y 15 dígitos');
         valid = false;
     }
 
@@ -80,10 +86,11 @@ const handleProfileSave = async (e) => {
     const user   = getCurrentUser();
     const name   = document.querySelector('#profile-name').value.trim();
     const email  = document.querySelector('#profile-email').value.trim();
+    const doc  = document.querySelector('#profile-document').value.trim();
     const btn    = document.querySelector('#btn-save-profile');
 
     // Verificar si hubo cambios reales
-    if (name === user.name && email === user.email) {
+    if (name === user.name && email === user.email && doc === String(user.document ?? '')) {
         showToast('No hay cambios para guardar', 'info');
         return;
     }
@@ -92,18 +99,33 @@ const handleProfileSave = async (e) => {
     btn.textContent = 'Guardando...';
 
     try {
-        const result = await updateProfile(user.id, { name, email });
+
+        const payload = { name, email };
+        if (doc && doc !== String(user.document ?? '')) payload.document = doc;
+        const result = await updateProfile(user.id, payload);
 
         if (!result.success) {
-            const msg = result.errors?.length
-                ? result.errors.map(e => e.message ?? e).join(', ')
-                : result.message;
-            showToast(msg, 'error');
+            if (result.errors?.length) {
+                result.errors.forEach(err => {
+                    const fieldMap = {
+                        document: 'profile-document-error',
+                        email:    'profile-email-error',
+                        name:     'profile-name-error',
+                    };
+                    const errorId = fieldMap[err.field];
+                    if (errorId) setFieldError(errorId, err.message);
+                });
+            } else {
+                showToast(result.message, 'error');  // ← solo si no hay errores de campo
+            }
             return;
         }
 
         // Actualizar datos en localStorage para reflejar los cambios
-        updateStoredUser({ name, email });
+        const updatedFields = { name, email };
+        if (payload.document) updatedFields.document = doc;
+
+        updateStoredUser(updatedFields);
         showToast(result.message, 'success');
 
     } catch (err) {

--- a/src/modules/settings/view/settings.view.js
+++ b/src/modules/settings/view/settings.view.js
@@ -47,9 +47,9 @@ export const settingsView = () => {
                     <div class="input-group">
                         <label for="profile-document">Documento</label>
                         <div class="input-wrapper">
-                            <input type="text" id="profile-document" value="${user.document ?? ''}" disabled class="input-disabled" />
+                            <input type="text" id="profile-document" value="${user.document ?? ''}" placeholder="Tu número de documento" />
                         </div>
-                        <span class="input-hint">El documento no puede modificarse</span>
+                        <span class="error-message hidden" id="profile-document-error"></span>
                     </div>
 
                     <div class="settings-form-actions">


### PR DESCRIPTION
## feat(users): edición de documento y validación de duplicados por campo

## Descripción

Hasta ahora el endpoint `PATCH /users/:id/profile` solo permitía editar nombre y correo. Este PR extiende esa funcionalidad para que el usuario también pueda actualizar su número de documento desde la pantalla de configuraciones.

Además se mejora el manejo de errores de duplicados tanto en la creación como en la edición de usuarios — antes se lanzaba un mensaje genérico, ahora el error viaja con el campo específico que lo causó para que el frontend pueda mostrarlo exactamente bajo el input correspondiente.

---

## Archivos modificados

| Archivo | Cambio |
|---|---|
| `src/models/user.model.js` | Agrega `findByEmail` para buscar usuarios por correo y poder verificar duplicados antes de guardar |
| `src/controller/users.controller.js` | `updateOwnProfile` acepta `document`, verifica que el nuevo email y documento no estén en uso por otro usuario, y retorna errores por campo. `createUser` distingue si el duplicado fue por email o documento y retorna el campo afectado |

---

## Detalle por endpoint

### `PATCH /users/:id/profile`

- **Antes:** aceptaba `name` y `email`
- **Ahora:** acepta `name`, `email` y `document`
- Si el email ya está en uso por otro usuario → `{ field: 'email', message: '...' }`
- Si el documento ya está en uso por otro usuario → `{ field: 'document', message: '...' }`
- Si el `id` del token no coincide con el `id` del parámetro → `403`

### `POST /users`

- **Antes:** error genérico `"El número de documento ya está registrado"` para cualquier duplicado
- **Ahora:** distingue si el duplicado fue en `email` o `document` y retorna el campo afectado con su mensaje específico

---

## Testing manual

- [ ] Usuario edita solo el nombre y guarda correctamente
- [ ] Usuario edita solo el correo y guarda correctamente
- [ ] Usuario edita solo el documento y guarda correctamente
- [ ] Error bajo campo `email` si el correo ya está en uso por otro usuario
- [ ] Error bajo campo `documento` si el documento ya está registrado por otro usuario
- [ ] Usuario no puede editar el perfil de otro usuario (`403`)
- [ ] Al crear usuario con email duplicado, error específico en campo `email`
- [ ] Al crear usuario con documento duplicado, error específico en campo `document`