### PR TITLE
fix(auth): mostrar errores de backend inline en registro y cambio de contraseña

### DIFF
--- a/src/modules/auth/controller/register.controller.js
+++ b/src/modules/auth/controller/register.controller.js
@@ -22,7 +22,40 @@ export const registerInit = () => {
     setupPasswordToggle('toggle-reg-password', 'reg-password');
     setupPasswordToggle('toggle-reg-password-confirm', 'reg-password-confirm');
 
+    // ========================================================
+    //         MAPA DE CAMPOS => IDs DE ERROR EN EL DOM
+    // ========================================================
+    const fieldMap = {
+        email:    'error-email',
+        document: 'error-documento',
+        name:     'error-fullname',
+    };
 
+    // ========================================================
+    //      UTILIDAD => LIMPIAR ERRORES INLINE DEL BACKEND
+    // ========================================================
+    const clearFieldErrors = () => {
+        Object.values(fieldMap).forEach(id => {
+            const el = document.querySelector(`#${id}`);
+            if (el) { el.textContent = ''; el.classList.add('hidden'); }
+        });
+    };
+
+    // ========================================================
+    //      UTILIDAD => MOSTRAR ERRORES BAJO EL CAMPO
+    // ========================================================
+    const showFieldErrors = (errors) => {
+        errors.forEach(err => {
+            const errorId = fieldMap[err.field];
+            if (!errorId) return;
+            const el = document.querySelector(`#${errorId}`);
+            if (el) {
+                el.textContent = err.message;
+                el.classList.remove('hidden');
+            }
+        });
+    };
+    
     // ========================================================
     //            EVENTO => RESTABLECER CONTRASEÑA
     // ========================================================
@@ -39,6 +72,9 @@ export const registerInit = () => {
             return;
         };
 
+        // Limpiar errores de campo previos antes de cada intento
+        clearFieldErrors();
+
         // Crear objeto con datos del formulario
         const userData = {
             name: formName.value.trim(),
@@ -50,17 +86,18 @@ export const registerInit = () => {
         const data = await register(userData);
 
         if (!data.success) {
-            const errorMessage = data.message || 'Error al registrar el usuario';
-            showToast(errorMessage, "error");
-            console.error('Error en registro:', data);
+    // Si el backend retorna errores por campo, mostrarlos inline
+            // Si no, mostrar un toast genérico con el mensaje del servidor
+            if (data.errors?.length) {
+                showFieldErrors(data.errors);
+            } else {
+                showToast(data.message || 'Error al registrar el usuario', 'error');
+            }
             return;
-        };
+        }
 
         showToast("Registro exitoso, ya puedes iniciar sesión", "success");
         form.reset();
-
-        setTimeout(() => {
-            navigateTo('/login');
-        }, 3000);
+        setTimeout(() => navigateTo('#/login'), 3000);
     });
 };

--- a/src/modules/settings/controller/settings.controller.js
+++ b/src/modules/settings/controller/settings.controller.js
@@ -197,10 +197,11 @@ const handlePasswordSave = async (e) => {
                     const errorId = fieldMap[err.field];
                     if (errorId) setFieldError(errorId, err.message);
                 });
-            }
-            showToast(result.message, 'error');
-            return;
-        }
+            } else {
+        showToast(result.message, 'error');
+    }
+    return;
+}
 
         // Limpiar el formulario tras éxito
         document.querySelector('#password-form').reset();


### PR DESCRIPTION
## fix(auth): errores de backend mostrados inline en registro y cambio de contraseña

## Descripción

Corrige el manejo de errores en los formularios de registro y cambio de contraseña. Los errores que retorna el backend ahora se muestran bajo el campo correspondiente en lugar de como toast genérico.

---

## Archivos modificados

| Archivo | Cambio |
|---|---|
| `src/modules/auth/controller/register.controller.js` | Errores de duplicado del backend se muestran inline bajo cada campo |
| `src/modules/settings/controller/settings.controller.js` | Errores de contraseña del backend se muestran inline — el toast solo aparece si no hay errores de campo |

---

## Detalle por cambio

### `register.controller.js`
- **Antes:** cualquier error del backend se mostraba como toast genérico
- **Ahora:** si el backend retorna errores por campo, se muestran inline bajo el input correspondiente

### `settings.controller.js`
- **Antes:** el toast de error siempre se mostraba aunque hubiera errores inline
- **Ahora:** el toast solo aparece si no hay errores de campo específicos

---

## Testing manual

- [ ] Registrar con documento duplicado → error inline bajo campo documento
- [ ] Registrar con correo duplicado → error inline bajo campo correo
- [ ] Registrar con documento y correo duplicados → ambos errores inline simultáneamente
- [ ] Cambiar contraseña con `currentPassword` incorrecta → error inline bajo campo contraseña actual
- [ ] Cambiar contraseña con `newPassword` igual a la actual → error inline bajo campo nueva contraseña
- [ ] Cambiar contraseña correctamente → éxito y formulario se limpia