### PR TITLE
fix(auth): validar nombre solo letras y limite de 100 caracteres en correo 

### DIFF
--- a/src/modules/auth/validation/forgot-password.validation.js
+++ b/src/modules/auth/validation/forgot-password.validation.js
@@ -22,6 +22,11 @@ export const validateForgotPasswordForm = () => {
         showContainer(errorEmail);
         isValid = false;
 
+    } else if (emailValue.length > 100) {
+        errorEmail.textContent = 'El correo electrónico no puede exceder los 100 caracteres';
+        showContainer(errorEmail);
+        isValid = false;
+
     } else {
         errorEmail.textContent = '';
         hideContainer(errorEmail);

--- a/src/modules/auth/validation/register.validation.js
+++ b/src/modules/auth/validation/register.validation.js
@@ -37,6 +37,10 @@ export const validateRegisterForm = () => {
         errorName.textContent = 'El nombre no puede exceder los 100 caracteres';
         showContainer(errorName);
         isValid = false;
+    } else if (!/^[a-zA-ZáéíóúÁÉÍÓÚñÑ\s]+$/.test(nameValue)) {
+        errorName.textContent = 'El nombre solo debe contener letras';
+        showContainer(errorName);
+        isValid = false;
     } else {
         errorName.textContent = '';
         hideContainer(errorName);
@@ -79,6 +83,10 @@ export const validateRegisterForm = () => {
         isValid = false;
     } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailValue)) {
         errorEmail.textContent = 'El correo electrónico no es válido';
+        showContainer(errorEmail);
+        isValid = false;
+    } else if (emailValue.length > 100) {
+        errorEmail.textContent = 'El correo electrónico no puede exceder los 100 caracteres';
         showContainer(errorEmail);
         isValid = false;
     } else {

--- a/src/modules/auth/view/register.view.js
+++ b/src/modules/auth/view/register.view.js
@@ -27,7 +27,7 @@ export const RegisterView = () => {
           <div class="input-group">
             <label for="email">Correo Electrónico</label>
             <div class="input-wrapper">
-              <input type="email" id="email" name="email" placeholder="correo@escuela.com">
+              <input id="email" name="email" placeholder="correo@escuela.com">
             </div>
             <span class="error-message hidden" id="error-email"></span>
           </div>


### PR DESCRIPTION
## Descripcion

Corrige validaciones faltantes en los formularios de registro y recuperacion de contrasena. Elimina la validacion nativa HTML5 del campo correo en el registro para unificar todas las validaciones bajo logica dinamica con mensajes de error renderizados bajo cada campo.

## Cambios principales

- Registro: valida que el nombre solo contenga letras (incluye acentos y ene).
- Registro: agrega limite de 100 caracteres al correo electronico.
- Registro: elimina atributo `type="email"` del input para evitar validacion HTML nativa.
- Recuperacion de contrasena: agrega limite de 100 caracteres al correo electronico.

## Como probar

1. Acceder a `#/register`.
2. Ingresar numeros en el campo nombre y verificar que bloquea con mensaje dinamico.
3. Ingresar correo con mas de 100 caracteres y verificar que bloquea.
4. Confirmar que el input de correo no muestra tooltip nativo del navegador.
5. Acceder a `#/forgot-password`.
6. Ingresar correo con mas de 100 caracteres y verificar que bloquea.

## Checklist

- [x] Nombre solo acepta letras en registro.
- [x] Correo limitado a 100 caracteres en registro.
- [x] Correo limitado a 100 caracteres en recuperacion de contrasena.
- [x] Validacion HTML nativa removida del input de correo.