### PR TITLE
feat(router):agregar vistas de error 404 y 403 con protección de permisos

### DIFF
--- a/src/modules/errors/forbidden.view.js
+++ b/src/modules/errors/forbidden.view.js
@@ -1,0 +1,22 @@
+export const forbiddenView = () => `
+    <section class="error-section">
+        <div class="error-card">
+            <div class="error-icon error-icon--403">
+                <svg width="48" height="48" viewBox="0 0 24 24" fill="none"
+                    stroke="currentColor" stroke-width="1.5"
+                    stroke-linecap="round" stroke-linejoin="round">
+                    <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+                    <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+                    <line x1="12" y1="16" x2="12" y2="16.01"></line>
+                </svg>
+            </div>
+            <h2 class="error-code">403</h2>
+            <h3 class="error-title">Acceso restringido</h3>
+            <p class="error-message">
+                No tienes los permisos necesarios para ver esta sección.
+                Contacta a tu administrador si crees que esto es un error.
+            </p>
+            <a href="#/home" class="btn btn--primary">Volver al inicio</a>
+        </div>
+    </section>
+`;

--- a/src/modules/errors/index.js
+++ b/src/modules/errors/index.js
@@ -1,0 +1,2 @@
+export { notFoundView } from './not-found.view.js';
+export { forbiddenView } from './forbidden.view.js';

--- a/src/modules/errors/not-found.view.js
+++ b/src/modules/errors/not-found.view.js
@@ -1,0 +1,22 @@
+export const notFoundView = () => `
+    <section class="error-section">
+        <div class="error-card">
+            <div class="error-icon error-icon--404">
+                <svg width="48" height="48" viewBox="0 0 24 24" fill="none"
+                    stroke="currentColor" stroke-width="1.5"
+                    stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="11" cy="11" r="8"></circle>
+                    <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                    <line x1="11" y1="8" x2="11" y2="11"></line>
+                    <line x1="11" y1="14" x2="11.01" y2="14"></line>
+                </svg>
+            </div>
+            <h2 class="error-code">404</h2>
+            <h3 class="error-title">Página no encontrada</h3>
+            <p class="error-message">
+                La ruta que intentas acceder no existe o fue eliminada.
+            </p>
+            <a href="#/home" class="btn btn--primary">Volver al inicio</a>
+        </div>
+    </section>
+`;

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -2,7 +2,10 @@ import { generateNavItems } from "../layout/index.js";
 import { headerLayout } from "../layout/index.js";
 import { headerInit } from "../layout/index.js";
 import { navigateTo } from "../utils/index.js";
+import { hasPermission } from "../utils/auth.utils.js";
 import { routes } from "./routes.js";
+import { notFoundView } from "../modules/errors/index.js";
+import { forbiddenView } from "../modules/errors/index.js";
 
 // ========================================================
 //   MONTAR LAYOUT SI NO EXISTE (solo rutas privadas)
@@ -71,16 +74,20 @@ const render = async () => {
     const path = window.location.hash || "#/login";
     const { route, params } = findRoute(path);
 
-    // 404
+
+    // 404 - Ruta no definida
     if (!route) {
-        const container = document.querySelector("#app");
-        container.innerHTML = `
-            <section class="home-section">
-                <h2>404</h2>
-                <p>Ruta no encontrada.</p>
-                <a href="#/home" class="btn">Volver al inicio</a>
-            </section>
-        `;
+        // Si hay sesión activa, mostrar el 404 dentro del layout
+        if (localStorage.getItem('user')) {
+            const ready = ensureLayout();
+            if (!ready) return;
+            const container = document.querySelector("#main-content");
+            container.innerHTML = notFoundView();
+        } else {
+            // Sin sesión: limpiar y mostrar el 404 sin layout
+            const container = document.querySelector("#app");
+            container.innerHTML = notFoundView();
+        }
         return;
     }
 
@@ -92,6 +99,12 @@ const render = async () => {
         if (!ready) return; // Fue redirigido a login
 
         const container = document.querySelector("#main-content");
+
+         // 403 - Ruta definida pero sin permisos
+        if (route.permission && !hasPermission(route.permission)) {
+            container.innerHTML = forbiddenView();
+            return;
+        }
 
         // Soporte para vistas sync y async
         const viewResult = route.view();

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -71,7 +71,8 @@ export const routes = [
     path: "#/tasks",
     view: () => tasksView(hasPermission('tasks.create')),
     init: (params) => tasksInit(params),
-    private: true
+    private: true,
+    permission: 'tasks.view'
     },
 
     // HASH DE EDITAR TAREA
@@ -79,7 +80,8 @@ export const routes = [
     path: "#/tasks/:id/edit",
     view: () => tasksView(hasPermission('tasks.create')),
     init: (params) => tasksInit(params),
-    private: true
+    private: true,
+    permission: 'tasks.update'
     },
 
     // HASH DE USUARIOS - ACTUALIZADO
@@ -94,7 +96,8 @@ export const routes = [
                 renderUsersList(container);
             }
         },
-        private: true
+        private: true,
+        permission: 'users.view'
     },
     // HASH DE CREACIÓN DE USUARIOS
     {
@@ -104,7 +107,8 @@ export const routes = [
             const container = document.querySelector("#user-create-container");
             if (container) renderCreateUser(container);
         },
-        private: true
+        private: true,
+        permission: 'users.create'
     },
     // --- HASH DE ASIGNACIÓN DE ROLES ---
     {
@@ -114,7 +118,8 @@ export const routes = [
             const container = document.querySelector("#user-assign-roles-container");
             if (container && params) renderAssignRoles(container, params);
         },
-        private: true
+        private: true,
+        permission: 'user-roles.assign'
     },
 
     // HASH DE ROLES Y PERMISOS
@@ -125,7 +130,8 @@ export const routes = [
             const container = document.querySelector("#roles-view-container");
             if (container) renderRolesList(container);
         },
-        private: true
+        private: true,
+        permission: 'roles.view'
     },
 
      // HASH CREAR ROL
@@ -136,7 +142,8 @@ export const routes = [
             const container = document.querySelector("#role-create-container");
             if (container) renderCreateRole(container);
         },
-        private: true
+        private: true,
+        permission: 'roles.create'
     },
     // HASH EDITAR ROL
     {
@@ -146,7 +153,8 @@ export const routes = [
             const container = document.querySelector("#role-edit-container");
             if (container && params) renderEditRole(container, params);
         },
-        private: true
+        private: true,
+        permission: 'roles.update'
     },
 
     // HASH DE CONFIGURACIONES

--- a/src/style.css
+++ b/src/style.css
@@ -2520,3 +2520,85 @@ textarea:disabled {
 .delete-account-text strong {
     color: var(--text-primary);
 }
+
+/* PÁGINAS DE ERROR (404 / 403) */
+
+.error-section {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: calc(100vh - var(--header-height));
+    padding: 40px 24px;
+}
+
+.error-card {
+    background: var(--bg-secondary);
+    border: 1px solid var(--bg-tertiary);
+    border-radius: var(--radius-md);
+    padding: 48px 40px;
+    max-width: 420px;
+    width: 100%;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+}
+
+.error-icon {
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 8px;
+}
+
+.error-icon--404 {
+    background: rgba(59, 130, 246, 0.1);
+    border: 1px solid rgba(59, 130, 246, 0.25);
+    color: var(--accent);
+}
+
+.error-icon--403 {
+    background: rgba(239, 68, 68, 0.1);
+    border: 1px solid rgba(239, 68, 68, 0.25);
+    color: var(--danger);
+}
+
+.error-code {
+    font-size: 64px;
+    font-weight: 700;
+    line-height: 1;
+    color: var(--text-muted);
+    letter-spacing: -2px;
+}
+
+.error-title {
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.error-message {
+    font-size: 14px;
+    color: var(--text-secondary);
+    line-height: 1.65;
+}
+
+.btn--primary {
+    margin-top: 8px;
+    background: var(--accent);
+    color: #fff;
+    padding: 10px 24px;
+    border-radius: var(--radius-sm);
+    text-decoration: none;
+    font-size: 14px;
+    font-weight: 500;
+    transition: background var(--transition);
+}
+
+.btn--primary:hover {
+    background: var(--accent-hover);
+}


### PR DESCRIPTION
## feat(router):agregar vistas de error 404 y 403 con protección de permisos.

## ¿Qué hace este PR?

Implementa el manejo de rutas no definidas (404) y acceso sin permisos (403)
mediante vistas dedicadas, reemplazando el bloque inline que existía en el router.

## Cambios

- `src/modules/errors/not-found.view.js` — vista 404
- `src/modules/errors/forbidden.view.js` — vista 403
- `src/modules/errors/index.js` — barrel del módulo
- `src/router/routes.js` — se agrega el campo `permission` a las rutas privadas que lo requieren
- `src/router/router.js` — se integra la verificación de permisos y las nuevas vistas de error
- `src/style.css` — estilos para `.error-section`, `.error-card`, `.error-icon--404`, `.error-icon--403`

## Comportamiento

| Caso | Resultado |
|------|-----------|
| Ruta no existe | Se muestra la vista 404 |
| Ruta existe pero sin permiso | Se muestra la vista 403 (el usuario permanece en la misma URL) |
| Ruta existe y tiene permiso | Renderiza normal |

## Notas

- Las rutas `#/home`, `#/settings` y `#/settings/edit` no tienen campo `permission`
  ya que cualquier usuario autenticado puede acceder.
- El Administrador siempre tiene acceso total (manejado en `hasPermission`).