### PR TITLE
fix(users): deshabilitar botón crear usuario sin permiso users.create

### DIFF
--- a/src/modules/users/view/users.view.js
+++ b/src/modules/users/view/users.view.js
@@ -3,7 +3,11 @@ export const usersView = () => {
         <div class="dashboard-container">
             <header class="view-header">
                 <h1 class="view-title">Gestión de Usuarios</h1>
-                <button id="btn-create-user" class="btn-primary">Crear Usuario</button>
+                ${(() => {
+                    const u = JSON.parse(localStorage.getItem('user') || '{}');
+                    const can = u.permissions?.some(p => p.code === 'users.create');
+                    return `<button id="btn-create-user" class="btn-primary" ${!can ? 'disabled style="opacity:0.4;cursor:not-allowed;"' : ''}>Crear Usuario</button>`;
+                })()}
             </header>
 
             <!-- Agregar buscador de usuarios -->


### PR DESCRIPTION
## Fix: Deshabilitar botón "Crear Usuario" sin permisos

### Cambios

- **Botón Crear Usuario:** Se deshabilita visualmente (opacity 0.4) si el usuario no tiene el permiso `users.create`.

### Archivos modificados
| Archivo | Cambio |
|---|---|
| `users.view.js` | Botón "Crear Usuario" condicional según permiso |

### Pruebas
- [x] Usuario sin permiso `users.create` → botón deshabilitado
- [x] Usuario con permiso `users.create` → botón funciona normalmente